### PR TITLE
Allow to change 'ORIGINAL' text in header

### DIFF
--- a/lib/afip_bill/generator.rb
+++ b/lib/afip_bill/generator.rb
@@ -7,20 +7,21 @@ require "pdfkit"
 
 module AfipBill
   class Generator
-    attr_reader :afip_bill, :bill_type, :user, :line_items
+    attr_reader :afip_bill, :bill_type, :user, :line_items, :header_text
 
     HEADER_PATH = File.dirname(__FILE__) + '/views/shared/_factura_header.html.erb'.freeze
     FOOTER_PATH = File.dirname(__FILE__) + '/views/shared/_factura_footer.html.erb'.freeze
     BRAVO_CBTE_TIPO = { "01" => "Factura A", "06" => "Factura B" }.freeze
     IVA = 21.freeze
 
-    def initialize(bill, user, line_items = [])
+    def initialize(bill, user, line_items = [], header_text = 'ORIGINAL')
       @afip_bill = JSON.parse(bill)
       @user = user
       @bill_type = type_a_or_b_bill
       @line_items = line_items
       @template_header = ERB.new(File.read(HEADER_PATH)).result(binding)
       @template_footer = ERB.new(File.read(FOOTER_PATH)).result(binding)
+      @header_text = header_text
     end
 
     def type_a_or_b_bill

--- a/lib/afip_bill/views/shared/_factura_header.html.erb
+++ b/lib/afip_bill/views/shared/_factura_header.html.erb
@@ -158,7 +158,7 @@
 
   </div>
 
-  <div style="left:263.78px;top:22.31px" class="cls_003"><span class="cls_003">ORIGINAL</span></div>
+  <div style="left:263.78px;top:22.31px" class="cls_003"><span class="cls_003"><%= header_text %></span></div>
   <div style="left:289.84px;top:43.90px" class="cls_009"><span class="cls_009"> <%= bill_type.upcase %> </span></div>
   <div style="left:341.00px;top:53.33px" class="cls_004"><span class="cls_004">FACTURA</span></div>
   <div style="left:70.00px;top:58.33px" class="cls_004"><span class="cls_004"> <%= AfipBill.configuration[:business_name] %></span></div>


### PR DESCRIPTION
Hey @lubc, @etagwerker,

This PR allows people to use "DUPLICADO" or "TRIPLICADO" as header text instead of the default "ORIGINAL". It should really be in one PDF file, but it's a temporary solution. 

Please check it out, thanks!