### PR TITLE
Use disable_smart_shrinking option to avoid shrunk PDF

### DIFF
--- a/lib/afip_bill/generator.rb
+++ b/lib/afip_bill/generator.rb
@@ -35,11 +35,11 @@ module AfipBill
     def generate_pdf_file
       tempfile = Tempfile.new("afip_bill.pdf")
 
-      PDFKit.new(template).to_file(tempfile.path)
+      pdfkit_template.to_file(tempfile.path)
     end
 
     def generate_pdf_string
-      PDFKit.new(template).to_pdf
+      pdfkit_template.to_pdf
     end
 
     private
@@ -63,6 +63,10 @@ module AfipBill
         cae: afip_bill["cae"],
         vto_cae: afip_bill["fch_vto_pago"]
       }
+    end
+
+    def pdfkit_template
+      PDFKit.new(template, disable_smart_shrinking: true)
     end
 
     def template


### PR DESCRIPTION
Hey @etagwerker, @lubc, 

This PR sets `wkhtmltopdf`'s `disable_smart_shrinking` option to `true` by default, to avoid shrinking the resulting PDF.

```
--disable-smart-shrinking       Disable the intelligent shrinking strategy
                                used by WebKit that makes the pixel/dpi
                                ratio none constant
```

(from https://wkhtmltopdf.org/usage/wkhtmltopdf.txt)

It's a small difference but the resulting PDF looks much better. 

We could make it `false` by default and have the user enable it in the `AfipBill` configuration, but I think having it set to `true` by default is a better experience. I don't have before/after examples, but I can attach them later if you want to see a comparison. 

Please let me know what you think, thanks!