### PR TITLE
Support for custom IVAs

### DIFF
--- a/lib/afip_bill/generator.rb
+++ b/lib/afip_bill/generator.rb
@@ -44,6 +44,8 @@ module AfipBill
 
     def alicuotas
       result = {}
+      return result unless type_a_or_b_bill == 'a'
+
       line_items.each { |i| result[i.iva_percentage] = result[i.iva_percentage].to_f + i.imp_iva }
       result
     end

--- a/lib/afip_bill/generator.rb
+++ b/lib/afip_bill/generator.rb
@@ -76,5 +76,9 @@ module AfipBill
     def template
       ERB.new(File.read(bill_path)).result(binding)
     end
+
+    def format_amount(amount)
+      ('%.2f' % amount.round(2).to_s).tr('.', ',')
+    end
   end
 end

--- a/lib/afip_bill/generator.rb
+++ b/lib/afip_bill/generator.rb
@@ -7,7 +7,7 @@ require "pdfkit"
 
 module AfipBill
   class Generator
-    attr_reader :afip_bill, :bill_type, :user, :line_items, :header_text
+    attr_reader :afip_bill, :bill_type, :user, :line_items, :header_text, :alicuotas
 
     HEADER_PATH = File.dirname(__FILE__) + '/views/shared/_factura_header.html.erb'.freeze
     FOOTER_PATH = File.dirname(__FILE__) + '/views/shared/_factura_footer.html.erb'.freeze
@@ -22,6 +22,7 @@ module AfipBill
       @template_header = ERB.new(File.read(HEADER_PATH)).result(binding)
       @template_footer = ERB.new(File.read(FOOTER_PATH)).result(binding)
       @header_text = header_text
+      @alicuotas = calculate_alicuotas
     end
 
     def type_a_or_b_bill
@@ -40,14 +41,6 @@ module AfipBill
 
     def generate_pdf_string
       PDFKit.new(template).to_pdf
-    end
-
-    def alicuotas
-      result = {}
-      return result unless type_a_or_b_bill == 'a'
-
-      line_items.each { |i| result[i.iva_percentage] = result[i.iva_percentage].to_f + i.imp_iva }
-      result
     end
 
     private
@@ -79,6 +72,14 @@ module AfipBill
 
     def format_amount(amount)
       ('%.2f' % amount.round(2).to_s).tr('.', ',')
+    end
+
+    def calculate_alicuotas
+      result = {}
+      return result unless type_a_or_b_bill == 'a'
+
+      line_items.each { |i| result[i.iva_percentage] = result[i.iva_percentage].to_f + i.imp_iva }
+      result
     end
   end
 end

--- a/lib/afip_bill/generator.rb
+++ b/lib/afip_bill/generator.rb
@@ -42,6 +42,12 @@ module AfipBill
       PDFKit.new(template).to_pdf
     end
 
+    def alicuotas
+      result = {}
+      line_items.each { |i| result[i.iva_percentage] = result[i.iva_percentage].to_f + i.imp_iva }
+      result
+    end
+
     private
 
     def bill_path

--- a/lib/afip_bill/line_item.rb
+++ b/lib/afip_bill/line_item.rb
@@ -1,6 +1,6 @@
 module AfipBill
   class LineItem
-    attr_reader :name, :quantity, :imp_unitario
+    attr_reader :name, :quantity, :imp_unitario, :iva_percentage
     DEFAULT_IVA_PERCENTAGE = 21.freeze
 
     def initialize(name, quantity, imp_unitario, iva_percentage = DEFAULT_IVA_PERCENTAGE)

--- a/lib/afip_bill/line_item.rb
+++ b/lib/afip_bill/line_item.rb
@@ -1,12 +1,13 @@
 module AfipBill
   class LineItem
     attr_reader :name, :quantity, :imp_unitario
-    IVA = 21.freeze
+    DEFAULT_IVA_PERCENTAGE = 21.freeze
 
-    def initialize(name, quantity, imp_unitario)
+    def initialize(name, quantity, imp_unitario, iva_percentage = DEFAULT_IVA_PERCENTAGE)
       @name = name
       @quantity = quantity
       @imp_unitario = imp_unitario
+      @iva_percentage = iva_percentage
     end
 
     def imp_total_unitario
@@ -14,7 +15,7 @@ module AfipBill
     end
 
     def imp_iva
-      imp_total_unitario * IVA / 100
+      imp_total_unitario * DEFAULT_IVA_PERCENTAGE / 100
     end
 
     def imp_total_unitario_con_iva

--- a/lib/afip_bill/line_item.rb
+++ b/lib/afip_bill/line_item.rb
@@ -15,7 +15,7 @@ module AfipBill
     end
 
     def imp_iva
-      imp_total_unitario * DEFAULT_IVA_PERCENTAGE / 100
+      imp_total_unitario * iva_percentage / 100
     end
 
     def imp_total_unitario_con_iva

--- a/lib/afip_bill/views/bills/factura_a.html.erb
+++ b/lib/afip_bill/views/bills/factura_a.html.erb
@@ -20,7 +20,7 @@
   <div style="left:360.54px;top:<%= top %>px" class="cls_008"><span class="cls_008"><%= line_item.imp_unitario.to_s.tr(".", ",") %></span></div>
   <div style="left:398.43px;top:<%= top %>px" class="cls_008"><span class="cls_008">0,00</span></div>
   <div style="width:60px;left:70.4%;top:<%= top %>px" class="cls_008"><span style="position:absolute;right:0" class="cls_008"><%= line_item.imp_total_unitario.round(2).to_s.tr(".", ",") %></span></div>
-  <div style="left:490.00px;top:<%= top %>px" class="cls_008"><span class="cls_008">21%</span></div>
+  <div style="left:490.00px;top:<%= top %>px" class="cls_008"><span class="cls_008"><%= "#{line_item.iva_percentage.to_s.tr('.', ',')}%" %></span></div>
   <div style="width:60px;left:87%;top:<%= top %>px" class="cls_008"><span style="position:absolute;right:0" class="cls_008"><%= line_item.imp_total_unitario_con_iva.round(2).to_s.tr(".", ",") %></span></div>
   <% top += 25 %>
 <% end %>

--- a/lib/afip_bill/views/bills/factura_a.html.erb
+++ b/lib/afip_bill/views/bills/factura_a.html.erb
@@ -39,23 +39,23 @@
 <div style="left:18.00px;top:567.63px" class="cls_008"><span class="cls_008">Per./Ret. Ingresos Brutos</span></div>
 <div style="left:331.43px;top:567.63px" class="cls_008"><span class="cls_008">0,00</span></div>
 <div style="left:456.98px;top:564.41px" class="cls_002"><span class="cls_002">IVA 27%: $</span></div>
-<div style="width:60px;left:86.6%;top:564.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas.fetch(27, 0)) %></span></div>
+<div style="width:60px;left:86.6%;top:564.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas[27].to_f) %></span></div>
 <div style="left:18.00px;top:578.63px" class="cls_008"><span class="cls_008">Impuestos Internos</span></div>
 <div style="left:331.43px;top:578.63px" class="cls_008"><span class="cls_008">0,00</span></div>
 <div style="left:18.00px;top:589.63px" class="cls_008"><span class="cls_008">Impuestos Municipales</span></div>
 <div style="left:331.43px;top:589.63px" class="cls_008"><span class="cls_008">0,00</span></div>
 <div style="left:456.98px;top:577.41px" class="cls_002"><span class="cls_002">IVA 21%: $</span></div>
-<div style="width:60px;left:86.6%;top:577.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas.fetch(21, 0)) %></span></div>
+<div style="width:60px;left:86.6%;top:577.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas[21].to_f) %></span></div>
 <div style="left:186.97px;top:602.91px" class="cls_006"><span class="cls_006">Importe Otros Tributos: $</span></div>
 <div style="left:329.49px;top:602.91px" class="cls_006"><span class="cls_006">0,00</span></div>
 <div style="left:449.48px;top:590.41px" class="cls_002"><span class="cls_002">IVA 10.5%: $</span></div>
-<div style="width:60px;left:86.6%;top:590.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas.fetch(10.5, 0)) %></span></div>
+<div style="width:60px;left:86.6%;top:590.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas[10.5].to_f) %></span></div>
 <div style="left:461.99px;top:603.41px" class="cls_002"><span class="cls_002">IVA 5%: $</span></div>
-<div style="width:60px;left:86.6%;top:603.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas.fetch(5, 0)) %></span></div>
+<div style="width:60px;left:86.6%;top:603.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas[5].to_f) %></span></div>
 <div style="left:454.48px;top:616.41px" class="cls_002"><span class="cls_002">IVA 2.5%: $</span></div>
-<div style="width:60px;left:86.6%;top:616.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas.fetch(2.5, 0)) %></span></div>
+<div style="width:60px;left:86.6%;top:616.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas[2.5].to_f) %></span></div>
 <div style="left:461.99px;top:629.41px" class="cls_002"><span class="cls_002">IVA 0%: $</span></div>
-<div style="width:60px;left:86.6%;top:629.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas.fetch(0, 0)) %></span></div>
+<div style="width:60px;left:86.6%;top:629.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas[0].to_f) %></span></div>
 <div style="left:394.49px;top:642.41px" class="cls_002"><span class="cls_002">Importe Otros Tributos: $</span></div>
 <div style="left:557.49px;top:642.41px" class="cls_002"><span class="cls_002">0,00</span></div>
 <div style="left:427.99px;top:656.29px" class="cls_005"><span class="cls_005">Importe Total: $</span></div>

--- a/lib/afip_bill/views/bills/factura_a.html.erb
+++ b/lib/afip_bill/views/bills/factura_a.html.erb
@@ -39,23 +39,23 @@
 <div style="left:18.00px;top:567.63px" class="cls_008"><span class="cls_008">Per./Ret. Ingresos Brutos</span></div>
 <div style="left:331.43px;top:567.63px" class="cls_008"><span class="cls_008">0,00</span></div>
 <div style="left:456.98px;top:564.41px" class="cls_002"><span class="cls_002">IVA 27%: $</span></div>
-<div style="left:557.49px;top:564.41px" class="cls_002"><span class="cls_002">0,00</span></div>
+<div style="left:557.49px;top:564.41px" class="cls_002"><span class="cls_002"><%= format_amount(alicuotas.fetch(27, 0)) %></span></div>
 <div style="left:18.00px;top:578.63px" class="cls_008"><span class="cls_008">Impuestos Internos</span></div>
 <div style="left:331.43px;top:578.63px" class="cls_008"><span class="cls_008">0,00</span></div>
 <div style="left:18.00px;top:589.63px" class="cls_008"><span class="cls_008">Impuestos Municipales</span></div>
 <div style="left:331.43px;top:589.63px" class="cls_008"><span class="cls_008">0,00</span></div>
 <div style="left:456.98px;top:577.41px" class="cls_002"><span class="cls_002">IVA 21%: $</span></div>
-<div style="width:60px;left:86.6%;top:577.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= afip_bill["imp_iva"] %></span></div>
+<div style="width:60px;left:86.6%;top:577.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas.fetch(21, 0)) %></span></div>
 <div style="left:186.97px;top:602.91px" class="cls_006"><span class="cls_006">Importe Otros Tributos: $</span></div>
 <div style="left:329.49px;top:602.91px" class="cls_006"><span class="cls_006">0,00</span></div>
 <div style="left:449.48px;top:590.41px" class="cls_002"><span class="cls_002">IVA 10.5%: $</span></div>
-<div style="left:557.49px;top:590.41px" class="cls_002"><span class="cls_002">0,00</span></div>
+<div style="left:557.49px;top:590.41px" class="cls_002"><span class="cls_002"><%= format_amount(alicuotas.fetch(10.5, 0)) %></span></div>
 <div style="left:461.99px;top:603.41px" class="cls_002"><span class="cls_002">IVA 5%: $</span></div>
-<div style="left:557.49px;top:603.41px" class="cls_002"><span class="cls_002">0,00</span></div>
+<div style="left:557.49px;top:603.41px" class="cls_002"><span class="cls_002"><%= format_amount(alicuotas.fetch(5, 0)) %></span></div>
 <div style="left:454.48px;top:616.41px" class="cls_002"><span class="cls_002">IVA 2.5%: $</span></div>
-<div style="left:557.49px;top:616.41px" class="cls_002"><span class="cls_002">0,00</span></div>
+<div style="left:557.49px;top:616.41px" class="cls_002"><span class="cls_002"><%= format_amount(alicuotas.fetch(2.5, 0)) %></span></div>
 <div style="left:461.99px;top:629.41px" class="cls_002"><span class="cls_002">IVA 0%: $</span></div>
-<div style="left:557.49px;top:629.41px" class="cls_002"><span class="cls_002">0,00</span></div>
+<div style="left:557.49px;top:629.41px" class="cls_002"><span class="cls_002"><%= format_amount(alicuotas.fetch(0, 0)) %></span></div>
 <div style="left:394.49px;top:642.41px" class="cls_002"><span class="cls_002">Importe Otros Tributos: $</span></div>
 <div style="left:557.49px;top:642.41px" class="cls_002"><span class="cls_002">0,00</span></div>
 <div style="left:427.99px;top:656.29px" class="cls_005"><span class="cls_005">Importe Total: $</span></div>

--- a/lib/afip_bill/views/bills/factura_a.html.erb
+++ b/lib/afip_bill/views/bills/factura_a.html.erb
@@ -39,7 +39,7 @@
 <div style="left:18.00px;top:567.63px" class="cls_008"><span class="cls_008">Per./Ret. Ingresos Brutos</span></div>
 <div style="left:331.43px;top:567.63px" class="cls_008"><span class="cls_008">0,00</span></div>
 <div style="left:456.98px;top:564.41px" class="cls_002"><span class="cls_002">IVA 27%: $</span></div>
-<div style="left:557.49px;top:564.41px" class="cls_002"><span class="cls_002"><%= format_amount(alicuotas.fetch(27, 0)) %></span></div>
+<div style="width:60px;left:86.6%;top:564.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas.fetch(27, 0)) %></span></div>
 <div style="left:18.00px;top:578.63px" class="cls_008"><span class="cls_008">Impuestos Internos</span></div>
 <div style="left:331.43px;top:578.63px" class="cls_008"><span class="cls_008">0,00</span></div>
 <div style="left:18.00px;top:589.63px" class="cls_008"><span class="cls_008">Impuestos Municipales</span></div>
@@ -49,13 +49,13 @@
 <div style="left:186.97px;top:602.91px" class="cls_006"><span class="cls_006">Importe Otros Tributos: $</span></div>
 <div style="left:329.49px;top:602.91px" class="cls_006"><span class="cls_006">0,00</span></div>
 <div style="left:449.48px;top:590.41px" class="cls_002"><span class="cls_002">IVA 10.5%: $</span></div>
-<div style="left:557.49px;top:590.41px" class="cls_002"><span class="cls_002"><%= format_amount(alicuotas.fetch(10.5, 0)) %></span></div>
+<div style="width:60px;left:86.6%;top:590.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas.fetch(10.5, 0)) %></span></div>
 <div style="left:461.99px;top:603.41px" class="cls_002"><span class="cls_002">IVA 5%: $</span></div>
-<div style="left:557.49px;top:603.41px" class="cls_002"><span class="cls_002"><%= format_amount(alicuotas.fetch(5, 0)) %></span></div>
+<div style="width:60px;left:86.6%;top:603.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas.fetch(5, 0)) %></span></div>
 <div style="left:454.48px;top:616.41px" class="cls_002"><span class="cls_002">IVA 2.5%: $</span></div>
-<div style="left:557.49px;top:616.41px" class="cls_002"><span class="cls_002"><%= format_amount(alicuotas.fetch(2.5, 0)) %></span></div>
+<div style="width:60px;left:86.6%;top:616.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas.fetch(2.5, 0)) %></span></div>
 <div style="left:461.99px;top:629.41px" class="cls_002"><span class="cls_002">IVA 0%: $</span></div>
-<div style="left:557.49px;top:629.41px" class="cls_002"><span class="cls_002"><%= format_amount(alicuotas.fetch(0, 0)) %></span></div>
+<div style="width:60px;left:86.6%;top:629.41px" class="cls_002"><span style="position:absolute;right:0" class="cls_002"><%= format_amount(alicuotas.fetch(0, 0)) %></span></div>
 <div style="left:394.49px;top:642.41px" class="cls_002"><span class="cls_002">Importe Otros Tributos: $</span></div>
 <div style="left:557.49px;top:642.41px" class="cls_002"><span class="cls_002">0,00</span></div>
 <div style="left:427.99px;top:656.29px" class="cls_005"><span class="cls_005">Importe Total: $</span></div>

--- a/spec/afip_bill/generator_spec.rb
+++ b/spec/afip_bill/generator_spec.rb
@@ -14,7 +14,10 @@ describe AfipBill::Generator do
   let(:bill) { File.read(bill_path) }
   let(:item_1) { AfipBill::LineItem.new("Item 1", 1, 100) }
   let(:item_2) { AfipBill::LineItem.new("Item 2", 1, 100) }
+  let(:item_3) { AfipBill::LineItem.new('Item 3', 1, 100, 10.5) }
 
+  let(:alicuotas_default) { subject.new(bill, user, [item_1, item_2]).alicuotas }
+  let(:alicuotas_mixed) { subject.new(bill, user, [item_1, item_2, item_3]).alicuotas }
   let(:pdf_file) { subject.new(bill, user, [item_1, item_2]).generate_pdf_file }
   let(:pdf_string) { subject.new(bill, user, [item_1, item_2]).generate_pdf_string }
 
@@ -28,6 +31,18 @@ describe AfipBill::Generator do
     AfipBill.configuration[:ingresos_brutos] = "901-111111-4"
     AfipBill.configuration[:iva] = "IVA Responsable Inscripto"
     AfipBill.configuration[:sale_point] = "005"
+  end
+
+  describe '#alicuotas' do
+    let(:type) { 'type_a' }
+
+    it 'should calculate alicuotas for default IVA (21%)' do
+      expect(alicuotas_default).to eq ({ 21 => 42 })
+    end
+
+    it 'should calculate alicoutas for mixed IVAs' do
+      expect(alicuotas_mixed).to eq ({ 21 => 42, 10.5 => 10.5 })
+    end
   end
 
   describe "generate_pdf" do

--- a/spec/afip_bill/generator_spec.rb
+++ b/spec/afip_bill/generator_spec.rb
@@ -34,14 +34,24 @@ describe AfipBill::Generator do
   end
 
   describe '#alicuotas' do
-    let(:type) { 'type_a' }
+    context 'Bill type A' do
+      let(:type) { 'type_a' }
 
-    it 'should calculate alicuotas for default IVA (21%)' do
-      expect(alicuotas_default).to eq ({ 21 => 42 })
+      it 'should calculate alicuotas for default IVA (21%)' do
+        expect(alicuotas_default).to eq ({ 21 => 42 })
+      end
+
+      it 'should calculate alicoutas for mixed IVAs' do
+        expect(alicuotas_mixed).to eq ({ 21 => 42, 10.5 => 10.5 })
+      end
     end
 
-    it 'should calculate alicoutas for mixed IVAs' do
-      expect(alicuotas_mixed).to eq ({ 21 => 42, 10.5 => 10.5 })
+    context 'Bill type B' do
+      let(:type) { 'type_b' }
+
+      it 'should return an empty hash' do
+        expect(alicuotas_default).to be_empty
+      end
     end
   end
 

--- a/spec/afip_bill/item_spec.rb
+++ b/spec/afip_bill/item_spec.rb
@@ -5,6 +5,7 @@ describe AfipBill::LineItem do
   subject { described_class }
 
   let(:item) { AfipBill::LineItem.new('Item', 1, 100) }
+  let(:item_custom_iva) { AfipBill::LineItem.new('Item', 1, 100, 5) }
   let(:item_zero_quantity) { AfipBill::LineItem.new('Item', 0, 100) }
   let(:item_multiple_units) { AfipBill::LineItem.new('Item', 10, 100) }
 
@@ -33,6 +34,16 @@ describe AfipBill::LineItem do
 
     it 'has imp_unitario' do
       expect(item.imp_unitario).to eq 100
+    end
+
+    describe 'iva_percentage' do
+      it 'has iva_percentage' do
+        expect(item_custom_iva.iva_percentage).to eq 5
+      end
+
+      it 'defaults to 21' do
+        expect(item.iva_percentage).to eq 21
+      end
     end
   end
 

--- a/spec/afip_bill/item_spec.rb
+++ b/spec/afip_bill/item_spec.rb
@@ -59,4 +59,20 @@ describe AfipBill::LineItem do
       end
     end
   end
+
+  describe '#imp_total_unitario_con_iva' do
+    describe 'default IVA (21%)' do
+      it 'should calculate imp_total_unitario_con_iva for quantity zero' do
+        expect(item_zero_quantity.imp_total_unitario_con_iva).to be_zero
+      end
+
+      it 'should calculate imp_total_unitario_con_iva for quantity one' do
+        expect(item.imp_total_unitario_con_iva).to eq 121
+      end
+
+      it 'should calculate imp_total_unitario_con_iva for quantity greater than one' do
+        expect(item_multiple_units.imp_total_unitario_con_iva).to eq 1210
+      end
+    end
+  end
 end

--- a/spec/afip_bill/item_spec.rb
+++ b/spec/afip_bill/item_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+require 'afip_bill/line_item'
+
+describe AfipBill::LineItem do
+  subject { described_class }
+
+  describe '#new' do
+    it 'must be created with name, quantity and imp_unitario' do
+      item = AfipBill::LineItem.new('Item', 1, 100)
+
+      expect(item).to be_an_instance_of AfipBill::LineItem
+    end
+  end
+end

--- a/spec/afip_bill/item_spec.rb
+++ b/spec/afip_bill/item_spec.rb
@@ -43,4 +43,10 @@ describe AfipBill::LineItem do
       expect(item_multiple_units.imp_total_unitario).to eq 1000
     end
   end
+
+  describe '#imp_iva' do
+    it 'should calculate imp_iva for default IVA (21%)' do
+      expect(item.imp_iva).to eq 21
+    end
+  end
 end

--- a/spec/afip_bill/item_spec.rb
+++ b/spec/afip_bill/item_spec.rb
@@ -5,6 +5,8 @@ describe AfipBill::LineItem do
   subject { described_class }
 
   let(:item) { AfipBill::LineItem.new('Item', 1, 100) }
+  let(:item_zero_quantity) { AfipBill::LineItem.new('Item', 0, 100) }
+  let(:item_multiple_units) { AfipBill::LineItem.new('Item', 10, 100) }
 
   describe '#new' do
     it 'must be created with name, quantity and imp_unitario' do
@@ -25,6 +27,20 @@ describe AfipBill::LineItem do
 
     it 'has imp_unitario' do
       expect(item.imp_unitario).to eq 100
+    end
+  end
+
+  describe '#imp_total_unitario' do
+    it 'should calculate imp_total_unitario for quantity zero' do
+      expect(item_zero_quantity.imp_total_unitario).to be_zero
+    end
+
+    it 'should calculate imp_total_unitario for quantity one' do
+      expect(item.imp_total_unitario).to eq 100
+    end
+
+    it 'should calculate imp_total_unitario for quantity greater than one' do
+      expect(item_multiple_units.imp_total_unitario).to eq 1000
     end
   end
 end

--- a/spec/afip_bill/item_spec.rb
+++ b/spec/afip_bill/item_spec.rb
@@ -4,11 +4,27 @@ require 'afip_bill/line_item'
 describe AfipBill::LineItem do
   subject { described_class }
 
+  let(:item) { AfipBill::LineItem.new('Item', 1, 100) }
+
   describe '#new' do
     it 'must be created with name, quantity and imp_unitario' do
       item = AfipBill::LineItem.new('Item', 1, 100)
 
       expect(item).to be_an_instance_of AfipBill::LineItem
+    end
+  end
+
+  describe 'attributes' do
+    it 'has name' do
+      expect(item.name).to eq 'Item'
+    end
+
+    it 'has quantity' do
+      expect(item.quantity).to eq 1
+    end
+
+    it 'has imp_unitario' do
+      expect(item.imp_unitario).to eq 100
     end
   end
 end

--- a/spec/afip_bill/item_spec.rb
+++ b/spec/afip_bill/item_spec.rb
@@ -14,6 +14,12 @@ describe AfipBill::LineItem do
 
       expect(item).to be_an_instance_of AfipBill::LineItem
     end
+
+    it 'can be created with name, quantity, imp_unitario, iva_percentage' do
+      item = AfipBill::LineItem.new('Item', 1, 100, 5)
+
+      expect(item).to be_an_instance_of AfipBill::LineItem
+    end
   end
 
   describe 'attributes' do

--- a/spec/afip_bill/item_spec.rb
+++ b/spec/afip_bill/item_spec.rb
@@ -5,9 +5,12 @@ describe AfipBill::LineItem do
   subject { described_class }
 
   let(:item) { AfipBill::LineItem.new('Item', 1, 100) }
-  let(:item_custom_iva) { AfipBill::LineItem.new('Item', 1, 100, 5) }
   let(:item_zero_quantity) { AfipBill::LineItem.new('Item', 0, 100) }
   let(:item_multiple_units) { AfipBill::LineItem.new('Item', 10, 100) }
+
+  let(:item_custom_iva) { AfipBill::LineItem.new('Item', 1, 100, 5) }
+  let(:item_custom_iva_zero_quantity) { AfipBill::LineItem.new('Item', 0, 100, 5) }
+  let(:item_custom_iva_multiple_units) { AfipBill::LineItem.new('Item', 10, 100, 5) }
 
   describe '#new' do
     it 'must be created with name, quantity and imp_unitario' do
@@ -75,6 +78,20 @@ describe AfipBill::LineItem do
         expect(item_multiple_units.imp_iva).to eq 210
       end
     end
+
+    describe 'custom IVA' do
+      it 'should calculate imp_iva for quantity zero' do
+        expect(item_custom_iva_zero_quantity.imp_iva).to be_zero
+      end
+
+      it 'should calculate imp_iva for quantity one' do
+        expect(item_custom_iva.imp_iva).to eq 5
+      end
+
+      it 'should calculate imp_iva for quantity greater than one' do
+        expect(item_custom_iva_multiple_units.imp_iva).to eq 50
+      end
+    end
   end
 
   describe '#imp_total_unitario_con_iva' do
@@ -89,6 +106,20 @@ describe AfipBill::LineItem do
 
       it 'should calculate imp_total_unitario_con_iva for quantity greater than one' do
         expect(item_multiple_units.imp_total_unitario_con_iva).to eq 1210
+      end
+    end
+
+    describe 'custom IVA' do
+      it 'should calculate imp_total_unitario_con_iva for quantity zero' do
+        expect(item_custom_iva_zero_quantity.imp_total_unitario_con_iva).to be_zero
+      end
+
+      it 'should calculate imp_total_unitario_con_iva for quantity one' do
+        expect(item_custom_iva.imp_total_unitario_con_iva).to eq 105
+      end
+
+      it 'should calculate imp_total_unitario_con_iva for quantity greater than one' do
+        expect(item_custom_iva_multiple_units.imp_total_unitario_con_iva).to eq 1050
       end
     end
   end

--- a/spec/afip_bill/item_spec.rb
+++ b/spec/afip_bill/item_spec.rb
@@ -45,8 +45,18 @@ describe AfipBill::LineItem do
   end
 
   describe '#imp_iva' do
-    it 'should calculate imp_iva for default IVA (21%)' do
-      expect(item.imp_iva).to eq 21
+    describe 'default IVA (21%)' do
+      it 'should calculate imp_iva for quantity zero' do
+        expect(item_zero_quantity.imp_iva).to be_zero
+      end
+
+      it 'should calculate imp_iva for quantity one' do
+        expect(item.imp_iva).to eq 21
+      end
+
+      it 'should calculate imp_iva for quantity greater than one' do
+        expect(item_multiple_units.imp_iva).to eq 210
+      end
     end
   end
 end


### PR DESCRIPTION
`AfipBill::LineItems` now support custom IVAs while maintaining support for previous releases (default is 21%).