### PR TITLE
Use cae_due_date as CAE expire date

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It must contain at least these attributes:
 ```ruby
 json_bill = {
   cae: "1234567890123",       # CAE number
+  cae_due_date: "20171125",   # CAE expiry date
   doc_num: "12345678901",     # CUIT number
   cbte_tipo: "01",            # Bill type (01 = A, 06 = B)
   cbte_fch: "20170125",       # Bill date

--- a/lib/afip_bill/generator.rb
+++ b/lib/afip_bill/generator.rb
@@ -61,7 +61,7 @@ module AfipBill
         cbte_tipo: afip_bill["cbte_tipo"],
         pto_venta: AfipBill.configuration[:sale_point],
         cae: afip_bill["cae"],
-        vto_cae: afip_bill["fch_vto_pago"]
+        vto_cae: afip_bill["cae_due_date"]
       }
     end
 

--- a/lib/afip_bill/views/shared/_factura_footer.html.erb
+++ b/lib/afip_bill/views/shared/_factura_footer.html.erb
@@ -3,7 +3,7 @@
 <div style="left:442.56px;top:688.54px" class="cls_005"><span class="cls_005">CAE N°:</span><span class="cls_007"> <%= afip_bill["cae"] %></span></div>
 <div style="left:16.00px;top:705.73px" class="cls_014"><span class="cls_014">Esta Administración Federal no se responsabiliza por los datos ingresados en el detalle de la operación</span></div>
 <div style="left:374.31px;top:702.54px" class="cls_005"><span class="cls_005">Fecha de Vto. de CAE:</span></div>
-<div style="left:486.00px;top:702.54px" class="cls_007"><span class="cls_007"><%= Date.parse(afip_bill["fch_vto_pago"]).strftime("%d/%m/%Y") %></span></div>
+<div style="left:486.00px;top:702.54px" class="cls_007"><span class="cls_007"><%= Date.parse(afip_bill["cae_due_date"]).strftime("%d/%m/%Y") %></span></div>
 <div style="left:100px;top:775px" class="cls_008"><span class="cls_008"><%= barcode.data %></span></div>
 
 <div style="left:16px;top:725px;">


### PR DESCRIPTION
The expiry date of the service payment is not the same as the CAE expiry date, so it should not be used as a replacement for it.
Generally, the CAE's expiry date is ten days away from the date of its generation.